### PR TITLE
Feature : Plain text support

### DIFF
--- a/apps/game-client/src/components/UserScriptSandboxModal.tsx
+++ b/apps/game-client/src/components/UserScriptSandboxModal.tsx
@@ -1,3 +1,4 @@
+// apps\game-client\src\components\UserScriptSandboxModal.tsx
 import React, { useState, useEffect } from 'react';
 import { useUserScriptSandbox } from '../hooks/useUserScriptSandbox';
 import {
@@ -40,7 +41,7 @@ export const UserScriptSandboxModal: React.FC<UserScriptSandboxModalProps> = ({ 
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
   const [editorName, setEditorName] = useState<string>('');
   const [editorSource, setEditorSource] = useState<string>('');
-  const [editorLanguage, setEditorLanguage] = useState<UserScriptLanguage>('javascript');
+  const [editorLanguage, setEditorLanguage] = useState<UserScriptLanguage>('text');
 
   // Trigger-specific state
   const [triggerEventName, setTriggerEventName] = useState<string>('example:event');
@@ -79,7 +80,7 @@ export const UserScriptSandboxModal: React.FC<UserScriptSandboxModalProps> = ({ 
       setSelectedScriptId(null);
       setEditorName('');
       setEditorSource('');
-      setEditorLanguage('javascript');
+      setEditorLanguage('text');
       setTriggerEventName('example:event');
       setTriggerMatchText('');
       setTriggerTestInput('');
@@ -94,7 +95,7 @@ export const UserScriptSandboxModal: React.FC<UserScriptSandboxModalProps> = ({ 
     setSelectedScriptId(null);
     setEditorName('');
     setEditorSource('');
-    setEditorLanguage('javascript');
+    setEditorLanguage('text');
     setTriggerEventName('example:event');
     setTriggerMatchText('');
     setTriggerTestInput('');
@@ -196,10 +197,9 @@ export const UserScriptSandboxModal: React.FC<UserScriptSandboxModalProps> = ({ 
       const s = createTrigger({
         name: 'New Trigger',
         enabled: false,
-        language: 'javascript',
-        source: `// Trigger example
-log("Trigger fired");
-sendCommand("say Hello from trigger");`,
+        language: 'text',
+        source: `say Trigger fired
+look`,
         eventName: 'example:event',
         matchText: '',
         omitFromOutput: false,
@@ -211,8 +211,8 @@ sendCommand("say Hello from trigger");`,
         name: 'New Alias',
         alias: 'l',
         enabled: false,
-        language: 'javascript',
-        source: `log("Alias executed")`,
+        language: 'text',
+        source: `look`,
       });
       handleSelectScript(s);
       setActiveTab('aliases');
@@ -220,10 +220,8 @@ sendCommand("say Hello from trigger");`,
       const s = createTimer({
         name: 'New Timer',
         enabled: false,
-        language: 'javascript',
-        source: `// Timer example
-log("Timer fired");
-sendCommand("score");`,
+        language: 'text',
+        source: `score`,
         intervalMs: 5000,
       });
       handleSelectScript(s);
@@ -285,7 +283,7 @@ sendCommand("score");`,
     setSelectedScriptId(null);
     setEditorName('');
     setEditorSource('');
-    setEditorLanguage('javascript');
+    setEditorLanguage('text');
     setTriggerEventName('example:event');
     setTriggerMatchText('');
     setTriggerTestInput('');
@@ -471,6 +469,7 @@ sendCommand("score");`,
                       value={editorLanguage}
                       onChange={(e) => setEditorLanguage(e.target.value as UserScriptLanguage)}
                     >
+                      <option value="text">Plain text</option>
                       <option value="javascript">JavaScript</option>
                       <option value="lua">Lua</option>
                       <option value="python">Python</option>
@@ -522,6 +521,7 @@ sendCommand("score");`,
                         value={triggerEventName}
                         onChange={(e) => setTriggerEventName(e.target.value)}
                       >
+                        <option value="game:terminal-data">game:terminal-data</option>
                         <option value="text:line">text:line</option>
                         <option value="gmcp:room">gmcp:room</option>
                         <option value="gmcp:affects">gmcp:affects</option>

--- a/apps/game-client/src/features/plugins/pluginScriptRunner.ts
+++ b/apps/game-client/src/features/plugins/pluginScriptRunner.ts
@@ -1,3 +1,4 @@
+// apps\game-client\src\features\plugins\pluginScriptRunner.ts
 import type { PluginBundledScript, PluginRuntimeApi, PluginId } from '@shatteredarchive/types-client';
 import type { AnyUserScript, UserScriptLanguage } from '../userScripts/types';
 import { runUserScript } from '../userScripts/runtime';

--- a/apps/game-client/src/features/userScripts/runtime.ts
+++ b/apps/game-client/src/features/userScripts/runtime.ts
@@ -88,8 +88,16 @@ export async function runUserScript(script: AnyUserScript, api: ScriptSandboxApi
   // Disabled scripts do nothing
   if (!script.enabled) return;
 
-  if (!script.source || !script.source.trim()) {
-    return;
+  // For plain text scripts, we intentionally allow empty/whitespace-only source
+  // because blank lines are meaningful (they should be sent as-is).
+  if (lang !== 'text') {
+    if (!script.source || !script.source.trim()) {
+      return;
+    }
+  } else {
+    if (script.source == null) {
+      return;
+    }
   }
 
   switch (lang) {

--- a/apps/game-client/src/features/userScripts/runtimeSingleton.ts
+++ b/apps/game-client/src/features/userScripts/runtimeSingleton.ts
@@ -1,6 +1,7 @@
 // apps\game-client\src\features\userScripts\runtimeSingleton.ts
 import { getAccessibilitySettings } from '../accessibility/accessibility-settings-store';
 import { UserScriptRuntime } from './userScriptRuntime';
+import type { AnyUserScript } from './types';
 
 const settings = getAccessibilitySettings();
 
@@ -12,3 +13,95 @@ window.addEventListener('sa:accessibility-updated', (e: any) => {
   const next = e?.detail;
   userScriptRuntime.setAliasSplitChar(next?.commandSplitChar);
 });
+
+const STORAGE_KEY_PREFIX = 'shatteredArchive.userScripts.';
+
+function getStorageKey(connectionId?: string | null) {
+  const safe = connectionId && connectionId.trim().length > 0 ? connectionId.trim() : 'default';
+  return `${STORAGE_KEY_PREFIX}${safe}`;
+}
+
+function loadScriptsFromStorage(connectionId?: string | null): AnyUserScript[] {
+  try {
+    const raw = window.localStorage.getItem(getStorageKey(connectionId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AnyUserScript[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function hydrateRuntime(connectionId?: string | null) {
+  // Replace runtime scripts with what’s in storage for this connection
+  userScriptRuntime.clear();
+
+  const scripts = loadScriptsFromStorage(connectionId);
+  for (const s of scripts) {
+    userScriptRuntime.upsertScript(s);
+  }
+}
+
+/**
+ * Keep runtime synced with:
+ * - initial page load
+ * - connection changes
+ * - sandbox saves (localStorage writes)
+ */
+(function initUserScriptRuntimeHydration() {
+  // initial hydrate (default connection)
+  hydrateRuntime('default');
+
+  window.addEventListener('game:connection-changed', (e: any) => {
+    const nextId = e?.detail?.connectionId ?? 'default';
+    hydrateRuntime(nextId);
+  });
+
+  // Listen to any localStorage update (including other tabs and same tab via manual dispatch)
+  window.addEventListener('storage', (e: StorageEvent) => {
+    if (!e.key) return;
+    if (!e.key.startsWith(STORAGE_KEY_PREFIX)) return;
+
+    // key format: shatteredArchive.userScripts.{connectionId}
+    const connectionId = e.key.slice(STORAGE_KEY_PREFIX.length) || 'default';
+    hydrateRuntime(connectionId);
+  });
+
+  // Same-tab writes do not trigger `storage`, so we also provide a manual event hook.
+  // We’ll fire this from useUserScriptSandbox when it saves.
+  window.addEventListener('game:userScripts-updated', (e: any) => {
+    const connectionId = e?.detail?.connectionId ?? 'default';
+    hydrateRuntime(connectionId);
+  });
+
+  function splitIntoLines(chunk: string): string[] {
+    // normalize to \n, then split; keep it simple and stable
+    const text = (chunk ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const lines = text.split('\n');
+
+    // drop final empty line caused by trailing newline
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+
+    return lines;
+  }
+
+  // Bridge terminal output into user-script triggers
+  window.addEventListener('game:terminal-data', (ev: any) => {
+    const detail = ev?.detail;
+
+    // Avoid triggers firing from plugin logs (optional but recommended)
+    if (detail?.__fromPlugin) return;
+
+    const text = String(detail?.text ?? '');
+    if (!text) return;
+    userScriptRuntime.dispatchEvent({
+      name: ev?.type ?? 'game:terminal-data',
+      payload: detail,
+    });
+    const lines = splitIntoLines(text);
+    for (const line of lines) {
+      // Payload can be string OR {text}, depending on what you want later
+      userScriptRuntime.dispatchEvent({ name: 'text:line', payload: { text: line } });
+    }
+  });
+})();

--- a/apps/game-client/src/features/userScripts/userScriptRuntime.ts
+++ b/apps/game-client/src/features/userScripts/userScriptRuntime.ts
@@ -77,6 +77,15 @@ export class UserScriptRuntime {
     for (const script of this.scripts.values()) {
       if (script.kind !== 'trigger' || !script.enabled) continue;
       if (script.eventName !== event.name) continue;
+
+      const trig: any = script;
+      const matchText = String(trig.matchText ?? '');
+      if (matchText) {
+        const p: any = event.payload;
+        const text = typeof p === 'string' ? p : String(p?.text ?? '');
+        if (!text.toLowerCase().includes(matchText.toLowerCase())) continue;
+      }
+
       this.executeScript(script, { event });
     }
   }

--- a/apps/game-client/src/hooks/usePlugins.ts
+++ b/apps/game-client/src/hooks/usePlugins.ts
@@ -1,3 +1,4 @@
+// apps\game-client\src\hooks\usePlugins.ts
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { PluginId } from '@shatteredarchive/types-client';
 import { findCorePlugin } from '../features/plugins/registry';

--- a/apps/game-client/src/hooks/useTerminal.ts
+++ b/apps/game-client/src/hooks/useTerminal.ts
@@ -1,3 +1,4 @@
+// apps\game-client\src\hooks\useTerminal.ts
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
@@ -161,6 +162,8 @@ export function useTerminal() {
       const text = e.detail?.text ?? '';
       const t = termRef.current;
       if (!text || !t) return;
+
+      if (shouldOmitLine('game:terminal-data', text)) return;
 
       let start = 0;
       let out: string | null = null;

--- a/apps/game-client/src/hooks/useUserScriptSandbox.ts
+++ b/apps/game-client/src/hooks/useUserScriptSandbox.ts
@@ -205,6 +205,15 @@ export function useUserScriptSandbox(connectionId?: string | null) {
 
     try {
       window.localStorage.setItem(key, JSON.stringify(scripts));
+      try {
+        window.dispatchEvent(
+          new CustomEvent('game:userScripts-updated', {
+            detail: { connectionId: connectionId ?? 'default' },
+          }),
+        );
+      } catch {
+        // ignore
+      }
     } catch (err) {
       console.error('[UserScriptSandbox] Failed to save scripts:', err);
     }
@@ -219,12 +228,14 @@ export function useUserScriptSandbox(connectionId?: string | null) {
     const omitRules = scripts
       .filter((s) => s.kind === 'trigger' && s.enabled)
       .filter((s: any) => !!s.omitFromOutput)
-      .map((s: any) => ({
-        id: s.id,
-        eventName: s.eventName || 'text:line',
-        matchText: s.matchText || '',
-        caseInsensitive: true,
-      }));
+      .flatMap((s: any) => {
+        const matchText = s.matchText || '';
+        // support both block + line
+        return [
+          { id: `${s.id}:line`, eventName: 'text:line', matchText, caseInsensitive: true },
+          { id: `${s.id}:block`, eventName: 'game:terminal-data', matchText, caseInsensitive: true },
+        ];
+      });
 
     setOmitRules(omitRules);
   }, [scripts]);

--- a/apps/game-client/src/styles/UserScriptSandboxModal.module.scss
+++ b/apps/game-client/src/styles/UserScriptSandboxModal.module.scss
@@ -1,3 +1,4 @@
+// apps\game-client\src\styles\UserScriptSandboxModal.module.scss
 .backdrop {
   position: fixed;
   inset: 0;

--- a/services/services-server/src/logger-service.ts
+++ b/services/services-server/src/logger-service.ts
@@ -2,38 +2,52 @@
 import path from 'path';
 import fs from 'fs';
 import winston from 'winston';
-import 'winston-daily-rotate-file';
+import DailyRotateFile from 'winston-daily-rotate-file'; // ✅ typed import
 
 import { ILogger, LoggerProps, LogLevel } from '@shatteredarchive/types-server';
 
 type ExtendedLoggerProps = LoggerProps & {
-  // Per-transport levels (optional)
   consoleLevel?: LogLevel;
   fileLevel?: LogLevel;
-
-  // Raw (text) file transport (optional)
   filePath?: string;
 
-  // JSONL disk logger (optional)
   diskJsonEnabled?: boolean;
   diskJsonLevel?: LogLevel;
   diskJsonPath?: string;
 
-  // If true, partition logs into <baseDir>/<YYYY>/<MM>/<DD>/
   datePartitioned?: boolean;
-
-  // NOTE: winston-daily-rotate-file may still create audit metadata files;
-  // there is no guaranteed "off" switch across versions.
   disableAuditFile?: boolean;
 
-  // Toggle logging when SOH (\u0001) is seen in payload
-  // (This gates ALL transports: console + file + jsonl.)
   diskToggleOnSoh?: boolean;
-
-  // Optional: only SOH lines on these event types toggle logging
-  // (recommended: ['game:remote-server:raw', 'game:client:input'])
   sohToggleEventTypes?: string[];
 };
+
+// ---- helpers to avoid `any` ----------------------------------------------
+
+type InfoWithExtras = winston.Logform.TransformableInfo & {
+  payload?: unknown;
+  timestamp?: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(v: unknown): v is UnknownRecord {
+  return typeof v === 'object' && v !== null;
+}
+
+function getRecordProp(obj: UnknownRecord, key: string): unknown {
+  return obj[key];
+}
+
+function getInfoPayload(info: winston.Logform.TransformableInfo): unknown {
+  return (info as InfoWithExtras).payload;
+}
+
+function getInfoTimestamp(info: winston.Logform.TransformableInfo): string {
+  return (info as InfoWithExtras).timestamp ?? new Date().toISOString();
+}
+
+// -------------------------------------------------------------------------
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
@@ -54,7 +68,7 @@ function resolvePartitionedPath(filePath: string, datePartitioned: boolean | und
   const d = pad2(now.getDate());
 
   const dir = path.dirname(filePath);
-  const base = path.basename(filePath); // keep file name as-is
+  const base = path.basename(filePath);
   return path.join(dir, y, m, d, base);
 }
 
@@ -77,11 +91,11 @@ function safeJsonStringify(obj: unknown): string {
   try {
     return JSON.stringify(obj);
   } catch (err) {
-    const e = err as Error;
+    const e = err instanceof Error ? err : new Error('unknown error');
     return JSON.stringify({
       type: 'logger:stringify-failed',
       timestamp: new Date().toISOString(),
-      payload: { error: e?.message ?? 'unknown error' },
+      payload: { error: e.message },
     });
   }
 }
@@ -95,14 +109,12 @@ function containsSoh(payload: unknown): boolean {
   if (typeof payload === 'string') return payload.includes(SOH);
   if (Buffer.isBuffer(payload)) return payload.includes(0x01);
 
-  if (typeof payload === 'object') {
-    const anyObj = payload as any;
-
-    const d = anyObj?.data;
+  if (isRecord(payload)) {
+    const d = getRecordProp(payload, 'data');
     if (typeof d === 'string' && d.includes(SOH)) return true;
     if (Buffer.isBuffer(d) && d.includes(0x01)) return true;
 
-    const t = anyObj?.text;
+    const t = getRecordProp(payload, 'text');
     if (typeof t === 'string' && t.includes(SOH)) return true;
     if (Buffer.isBuffer(t) && t.includes(0x01)) return true;
   }
@@ -130,12 +142,11 @@ export function createSohGateFormat(args: {
     sohToggleEventTypes,
     containsSohFn = containsSoh,
     getEventType = (info) => String(info.message ?? ''),
-    getPayload = (info) => (info as any).payload,
+    getPayload = (info) => getInfoPayload(info), // ✅ no any
   } = args;
 
   const sohTypes = sohToggleEventTypes?.length ? new Set(sohToggleEventTypes) : undefined;
 
-  // Closure owns toggle state for this format instance
   let loggingEnabled = true;
 
   return winston.format((info) => {
@@ -147,7 +158,7 @@ export function createSohGateFormat(args: {
     const canToggle = !sohTypes || sohTypes.has(eventType);
     if (canToggle && containsSohFn(payload)) {
       loggingEnabled = !loggingEnabled;
-      return false; // drop the SOH marker line itself
+      return false;
     }
 
     if (!loggingEnabled) return false;
@@ -170,9 +181,7 @@ export class Logger implements ILogger {
       sohToggleEventTypes: props.sohToggleEventTypes,
     });
 
-    // ------------------------
     // Console transport (GATED)
-    // ------------------------
     const consoleLevel = props.consoleLevel ?? props.level;
 
     transports.push(
@@ -184,18 +193,15 @@ export class Logger implements ILogger {
           winston.format.colorize(),
           winston.format.printf((info) => {
             const type = String(info.message ?? '');
-            const payload = (info as any).payload;
-            const hasPayload = payload !== undefined;
-            const payloadPart = hasPayload ? ` ${safeJsonStringify(toJsonSafe(payload))}` : '';
-            return `[${(info as any).timestamp}] ${String(info.level)}: ${type}${payloadPart}`;
+            const payload = getInfoPayload(info);
+            const payloadPart = payload !== undefined ? ` ${safeJsonStringify(toJsonSafe(payload))}` : '';
+            return `[${getInfoTimestamp(info)}] ${String(info.level)}: ${type}${payloadPart}`;
           }),
         ),
       }),
     );
 
-    // ------------------------
     // Rotating raw file transport (optional, GATED)
-    // ------------------------
     if (props.filePath) {
       const resolved = resolvePartitionedPath(props.filePath, props.datePartitioned);
       const dir = path.dirname(resolved);
@@ -207,33 +213,29 @@ export class Logger implements ILogger {
       const fileLevel = props.fileLevel ?? props.level;
 
       transports.push(
-        new (winston.transports as any).DailyRotateFile({
+        new DailyRotateFile({
           dirname: dir,
           filename: `${base}-%DATE%${ext}`,
           datePattern: 'YYYY-MM-DD',
           maxSize: props.maxSize ?? undefined,
-          maxFiles: props.maxFiles ?? undefined, // undefined = keep forever
+          maxFiles: props.maxFiles ?? undefined,
           level: fileLevel,
-          // NOTE: no reliable "disable audit file" across versions; leaving undefined uses library defaults
           auditFile: undefined,
           format: winston.format.combine(
             sohGate(),
             winston.format.timestamp(),
             winston.format.printf((info) => {
               const type = String(info.message ?? '');
-              const payload = (info as any).payload;
-              const hasPayload = payload !== undefined;
-              const payloadPart = hasPayload ? ` ${safeJsonStringify(toJsonSafe(payload))}` : '';
-              return `[${(info as any).timestamp}] ${String(info.level)}: ${type}${payloadPart}`;
+              const payload = getInfoPayload(info);
+              const payloadPart = payload !== undefined ? ` ${safeJsonStringify(toJsonSafe(payload))}` : '';
+              return `[${getInfoTimestamp(info)}] ${String(info.level)}: ${type}${payloadPart}`;
             }),
           ),
         }),
       );
     }
 
-    // ------------------------
     // Disk JSONL transport (optional, GATED)
-    // ------------------------
     if (props.diskJsonEnabled && props.diskJsonPath) {
       const resolved = resolvePartitionedPath(props.diskJsonPath, props.datePartitioned);
       const dir = path.dirname(resolved);
@@ -245,12 +247,12 @@ export class Logger implements ILogger {
       const diskJsonLevel = props.diskJsonLevel ?? props.level;
 
       transports.push(
-        new (winston.transports as any).DailyRotateFile({
+        new DailyRotateFile({
           dirname: dir,
           filename: `${base}-%DATE%${ext}`,
           datePattern: 'YYYY-MM-DD',
           maxSize: props.maxSize ?? undefined,
-          maxFiles: props.maxFiles ?? undefined, // undefined = keep forever
+          maxFiles: props.maxFiles ?? undefined,
           level: diskJsonLevel,
           auditFile: undefined,
           format: winston.format.combine(
@@ -258,22 +260,20 @@ export class Logger implements ILogger {
             winston.format.timestamp(),
             winston.format.printf((info) => {
               const type = String(info.message ?? '');
-              const payloadRaw = (info as any).payload;
+              const payloadRaw = getInfoPayload(info);
               const payload = toJsonSafe(payloadRaw);
 
-              const subtype =
-                payloadRaw &&
-                typeof payloadRaw === 'object' &&
-                typeof (payloadRaw as any).type === 'string' &&
-                (payloadRaw as any).type
-                  ? String((payloadRaw as any).type)
-                  : '';
+              let subtype = '';
+              if (isRecord(payloadRaw)) {
+                const t = getRecordProp(payloadRaw, 'type');
+                if (typeof t === 'string' && t) subtype = t;
+              }
 
               return safeJsonStringify({
                 type,
                 subtype,
                 level: String(info.level ?? ''),
-                timestamp: String((info as any).timestamp ?? new Date().toISOString()),
+                timestamp: getInfoTimestamp(info),
                 payload,
               });
             }),
@@ -282,7 +282,6 @@ export class Logger implements ILogger {
       );
     }
 
-    // ---- EXTENSION HOOK FOR CLOUD LOGGING (AZURE / AWS) ----
     if (props.extendTransports) {
       const extended = props.extendTransports(transports, props);
       transports.length = 0;


### PR DESCRIPTION
# Pull Request

## Summary

- Adds trigger, alias, timer support for plain text. One sent command per line. Makes plain text default
- Allows omit:block when triggering off of game:terminal-data
- Lint-fixes
- BUGFIX: Triggers work again

---

## Type of Change

Please check all that apply:

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] Performance improvement
- [ ] Other (please describe)

---

## Motivation and Context

Many users are not technical, add plain text support so that triggers, alias, and timers accept plain text commands - one per line - to widen feature usage

---

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Not tested (please explain)

Provide details if applicable:

---

## Checklist

Please confirm the following before requesting review:

- [x] My code follows the project’s coding standards
- [x] I ran `pnpm lint`
- [x] I ran `pnpm test` (including coverage)
- [x] I ran `pnpm build`
- [ ] I have added or updated tests where appropriate
- [ ] I have updated documentation where necessary
- [x] This change targets `release/dev` (unless otherwise discussed)

---

## Breaking Changes

- [ ] This change introduces breaking changes
- [ ] This change does not introduce breaking changes

If yes, please describe the impact and any required migration steps:

---

## Additional Notes

Add any additional context, screenshots, or references here.
